### PR TITLE
feat: add configuration for init, fix rpi-dac audio bug

### DIFF
--- a/src/audioout/audioout_pygame.py
+++ b/src/audioout/audioout_pygame.py
@@ -11,18 +11,21 @@ from viam.resource.types import Model, ModelFamily
 from .api import Audioout
 from viam.logging import getLogger
 
-import time
-import asyncio
 import pygame
 from pygame import mixer
 
 LOGGER = getLogger(__name__)
-mixer.init(buffer=1024)
 
 class audioout_pygame(Audioout, Reconfigurable):
     
     MODEL: ClassVar[Model] = Model(ModelFamily("viam-labs", "audioout"), "pygame")
-    
+
+    bitsize: int
+    buffer: int
+    channels: int
+    frequency: int
+    volume: float
+
     # Constructor
     @classmethod
     def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:
@@ -30,18 +33,40 @@ class audioout_pygame(Audioout, Reconfigurable):
         my_class.reconfigure(config, dependencies)
         return my_class
 
+    @classmethod
+    def validate(cls, config: ComponentConfig):
+        return []
+
     # Handles attribute reconfiguration
     def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
+        self.bitsize = int(config.attributes.fields["bitsize"].number_value or -16)
+        self.buffer = int(config.attributes.fields["buffer"].number_value or 1024)
+        self.channels = int(config.attributes.fields["channels"].number_value or 2)
+        self.frequency = int(config.attributes.fields["frequency"].number_value or 44100)
+        self.volume = config.attributes.fields["default_volume"].number_value or 1.0
+
+        if mixer.pre_init() is None:
+            mixer.init(self.frequency, self.bitsize, self.channels, self.buffer)
+
+        # clear any playing channels
+        mixer.stop()
+
+        # release resources
+        mixer.quit()
         return
 
     async def play(self, file_path: str, loop_count: int, maxtime_ms: int, fadein_ms: int, block: bool) -> str:
         LOGGER.info("Will play audio, blocking: " + str(block))
+        if mixer.pre_init() is None:
+            mixer.init(self.frequency, self.bitsize, self.channels, self.buffer)
+            mixer.music.set_volume(self.volume)
+
         try:
             if os.path.isfile(file_path):
                 mixer.music.load(file_path) 
                 mixer.music.play(loop_count, maxtime_ms, fadein_ms)
 
-                if block == True:
+                if block:
                     while mixer.music.get_busy():
                         pygame.time.Clock().tick()
                         


### PR DESCRIPTION
The main issue with the rpi-dac interface (used by the i2s amp) and this module, as I understand it, is the initialization of the `pygame.mixer` in the module process causes background static on the `mixer.music` channel. I was able to resolve this by initializing the mixer, stopping sound on all channels, then de-initializing the mixer before the first time `play` is called. 